### PR TITLE
Extract general purpose DataLoader pattern from VC

### DIFF
--- a/lib/iopromise/data_loader.rb
+++ b/lib/iopromise/data_loader.rb
@@ -4,8 +4,8 @@ module IOPromise
   module DataLoader
     module ClassMethods
       def attr_promised_data(*args)
-        @promised_data ||= []
-        @promised_data.concat(args)
+        @promised_data_keys ||= []
+        @promised_data_keys.concat(args)
 
         args.each do |arg|
           self.class_eval("def #{arg};@#{arg}.sync;end")
@@ -13,7 +13,7 @@ module IOPromise
       end
   
       def promised_data_keys
-        @promised_data ||= []
+        @promised_data_keys ||= []
       end
     end
 
@@ -47,7 +47,7 @@ module IOPromise
     end
 
     def data_as_promise
-      @data_promise ||= Promise.all(data_promises)
+      @data_as_promise ||= Promise.all(data_promises)
     end
 
     def sync

--- a/lib/iopromise/data_loader.rb
+++ b/lib/iopromise/data_loader.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module IOPromise
+  module DataLoader
+    module ClassMethods
+      def attr_promised_data(*args)
+        @promised_data ||= []
+        @promised_data.concat(args)
+
+        args.each do |arg|
+          self.class_eval("def #{arg};@#{arg}.sync;end")
+        end
+      end
+  
+      def promised_data_keys
+        @promised_data ||= []
+      end
+    end
+
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    def data_promises
+      self.class.promised_data_keys.flat_map do |k|
+        p = instance_variable_get('@' + k.to_s)
+        case p
+        when ::IOPromise::DataLoader
+          # greedily, recursively preload all nested data that we know about immediately
+          p.data_promises
+        when ::Promise
+          # allow nesting of dataloaders chained behind other promises
+          resolved = p.then do |result|
+            if result.is_a?(::IOPromise::DataLoader)
+              # likewise, if we resolved a promise that we can recurse, load that data too.
+              result.data_as_promise
+            else
+              result
+            end
+          end
+
+          [resolved]
+        else
+          raise TypeError.new("Instance variable #{k.to_s} used with attr_promised_data but was not a promise or a IOPromise::DataLoader.")
+        end
+      end
+    end
+
+    def data_as_promise
+      @data_promise ||= Promise.all(data_promises)
+    end
+
+    def sync
+      data_as_promise.sync
+      self
+    end
+  end
+end

--- a/lib/iopromise/view_component/data_loader.rb
+++ b/lib/iopromise/view_component/data_loader.rb
@@ -1,56 +1,15 @@
 # frozen_string_literal: true
 
+require_relative "../data_loader"
 require "view_component/engine"
 
 module IOPromise
   module ViewComponent
     module DataLoader
-      module ClassMethods
-        def attr_promised_data(*args)
-          @promised_data ||= []
-          @promised_data.concat(args)
-
-          args.each do |arg|
-            self.class_eval("def #{arg};@#{arg}.sync;end")
-          end
-        end
-    
-        def promised_data_keys
-          @promised_data ||= []
-        end
-      end
+      include ::IOPromise::DataLoader
 
       def self.included(base)
-        base.extend(ClassMethods)
-      end
-
-      def data_as_promise
-        @data_promise ||= begin
-          promises = self.class.promised_data_keys.map do |k|
-            p = instance_variable_get('@' + k.to_s)
-            if p.is_a?(IOPromise::ViewComponent::DataLoader)
-              # recursively preload all nested data
-              p.data_as_promise
-            else
-              # for any local promises, we'll unwrap them before completing
-              p.then do |result|
-                if result.is_a?(IOPromise::ViewComponent::DataLoader)
-                  # likewise, if we resolved a promise that we can recurse, load that data too.
-                  result.data_as_promise
-                else
-                  result
-                end
-              end
-            end
-          end
-
-          Promise.all(promises)
-        end
-      end
-
-      def sync
-        data_as_promise.sync
-        self
+        base.extend(::IOPromise::DataLoader::ClassMethods)
       end
 
       def render_in(*)

--- a/spec/data_loader_spec.rb
+++ b/spec/data_loader_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'iopromise'
+require 'iopromise/deferred'
+require 'iopromise/data_loader'
+
+RSpec.describe IOPromise::DataLoader do
+  class ExampleDataLoader
+    include IOPromise::DataLoader
+
+    attr_promised_data :foo
+    attr_promised_data :bar
+
+    def initialize(data_source)
+      @foo = IOPromise::Deferred.new { data_source[:foo] }
+      @bar = IOPromise::Deferred.new { data_source[:bar] }
+    end
+  end
+
+  class AnotherDataLoader
+    include IOPromise::DataLoader
+
+    attr_promised_data :baz
+
+    def initialize(data_source)
+      @baz = IOPromise::Deferred.new { data_source[:baz] }
+    end
+  end
+
+  class BrokenDataLoader
+    include IOPromise::DataLoader
+
+    attr_promised_data :broken
+
+    def initialize
+      @broken = ::Promise.new
+      @broken.reject('rejection reason')
+    end
+  end
+
+  class ParentDataLoader
+    include IOPromise::DataLoader
+    attr_promised_data :parent_thing, :example_component, :another_component
+
+    def initialize(data_source)
+      @parent_thing = IOPromise::Deferred.new { data_source[:parent_thing] }
+      @example_component = ExampleDataLoader.new(data_source)
+      @another_component = AnotherDataLoader.new(data_source)
+    end
+  end
+
+  it "registers the promised data keys for the class" do
+    expect(ExampleDataLoader.promised_data_keys).to eq([:foo, :bar])
+    expect(AnotherDataLoader.promised_data_keys).to eq([:baz])
+    expect(BrokenDataLoader.promised_data_keys).to eq([:broken])
+  end
+
+  it "creates attr readers that sync and handle success by returning a value" do
+    example = ExampleDataLoader.new({ :foo => 123, :bar => 456 })
+    expect(example.foo).to eq(123)
+    expect(example.bar).to eq(456)
+  end
+
+  it "creates attr readers that sync and handle failure by raising the reason" do
+    broken = BrokenDataLoader.new
+    expect { broken.broken }.to raise_exception('rejection reason')
+  end
+
+  it "provides a data_as_promise which syncs all promises, including chained ones" do
+    data_source = {}
+    parent = ParentDataLoader.new(data_source)
+    example = parent.instance_variable_get('@example_component')
+    another = parent.instance_variable_get('@another_component')
+
+    # get our promise data source
+    ds_promise = parent.data_as_promise
+    expect(parent.instance_variable_get('@parent_thing')).to be_pending
+    expect(example.instance_variable_get('@foo')).to be_pending
+    expect(example.instance_variable_get('@bar')).to be_pending
+    expect(another.instance_variable_get('@baz')).to be_pending
+
+    # set the data source values, just to really make sure this has to have happened after now
+    data_source[:foo] = 123
+    data_source[:bar] = 456
+    data_source[:baz] = 987
+    data_source[:parent_thing] = 789
+
+    # sync on the full data tree
+    ds_promise.sync
+    expect(parent.instance_variable_get('@parent_thing')).to be_fulfilled
+    expect(example.instance_variable_get('@foo')).to be_fulfilled
+    expect(example.instance_variable_get('@bar')).to be_fulfilled
+    expect(another.instance_variable_get('@baz')).to be_fulfilled
+
+    # and finally, the values should have propagated
+    expect(parent.parent_thing).to eq(789)
+    expect(example.foo).to eq(123)
+    expect(example.bar).to eq(456)
+    expect(another.baz).to eq(987)
+  end
+end


### PR DESCRIPTION
Currently the ViewComponent helper in this project adds a nice DataLoader pattern, but specific to ViewComponent. This PR extracts the generic DataLoader pattern so it can be used separately, and leaves the one pre-render step in the ViewComponent extension.

The way this works is best seen from the tests, like this excerpt:
```ruby
  class ExampleDataLoader
    include IOPromise::DataLoader

    attr_promised_data :foo
    attr_promised_data :bar

    def initialize(data_source)
      @foo = IOPromise::Deferred.new { data_source[:foo] }
      @bar = IOPromise::Deferred.new { data_source[:bar] }
    end
  end
```

Which then allows for:
```ruby
irb(main):016:0> example = ExampleDataLoader.new({ :foo => 123, :bar => 456 })
=> #<ExampleDataLoader:0x0000558659294778 @foo=#<IOPromise::Deferred::DeferredPromise:0x0000558659294728 @state=:pending, @block=#<Proc:0x0000558659294638 (irb):12>>, @bar=#<IOPromise::Deferred::DeferredPromise:0x00005586592943e0 @state=:pending, @block=#<Proc:0x00...
irb(main):017:0> 
irb(main):018:0> example.sync
=> #<ExampleDataLoader:0x0000558659294778 @foo=#<IOPromise::Deferred::DeferredPromise:0x0000558659294728 @state=:fulfilled, @block=#<Proc:0x0000558659294638 (irb):12>, @source=nil, @observers=nil, @started_executing=true, @value=123>, @bar=#<IOPromise::Deferred::DeferredPromise:0x00005586592943e0 @state=:fulfilled, @block=#<Proc:0x00005586592943b8 (irb):13>, @source=nil, @observers=nil, @started_executing=true, @value=456>, @data_promise=#<Promise:0x000055865912a798 @state=:fulfilled, @source=nil, @value=[123, 456]>>
irb(main):019:0> example.foo
=> 123
irb(main):020:0> example.bar
=> 456
irb(main):021:0> 
```

As before, the promised data can also be another object including `DataLoader`, in which case the loads will be recursively brought in to the load chain.

This means that any class can declaratively specify attributes that are promises, and have the entire nested set of pending data loads happen in one place, without having a requirement that they use ViewComponent.

/cc @tma @mclark 