### PR TITLE
Ensure IOPromises end when a request/block ends with CancelContext

### DIFF
--- a/lib/iopromise.rb
+++ b/lib/iopromise.rb
@@ -4,6 +4,7 @@ require "promise"
 
 require_relative "iopromise/version"
 
+require_relative "iopromise/cancel_context"
 require_relative "iopromise/executor_context"
 require_relative "iopromise/executor_pool/base"
 require_relative "iopromise/executor_pool/batch"
@@ -54,7 +55,7 @@ module IOPromise
     # propegation once this promise has been cancelled.
     def cancel
       return unless pending?
-
+      
       @cancelled = true
       @observers = []
     end

--- a/lib/iopromise.rb
+++ b/lib/iopromise.rb
@@ -43,19 +43,19 @@ module IOPromise
     end
 
     def fulfill(value)
-      return if defined?(@cancelled)
+      return if cancelled?
       notify_completion(value: value)
       super(value)
     end
 
     def reject(reason)
-      return if defined?(@cancelled)
+      return if cancelled?
       notify_completion(reason: reason)
       super(reason)
     end
 
     def wait
-      raise IOPromise::CancelledError if defined?(@cancelled)
+      raise IOPromise::CancelledError if cancelled?
       super
     end
 

--- a/lib/iopromise.rb
+++ b/lib/iopromise.rb
@@ -49,5 +49,26 @@ module IOPromise
       notify_completion(reason: reason)
       super(reason)
     end
+
+    # makes this promise inert, ensuring that promise chains do not continue
+    # propegation once this promise has been cancelled.
+    def cancel
+      return unless pending?
+
+      @cancelled = true
+      @observers = []
+    end
+
+    def notify_fulfillment
+      super unless defined?(@cancelled)
+    end
+
+    def notify_rejection
+      super unless defined?(@cancelled)
+    end
+
+    def cancelled?
+      !!defined?(@cancelled)
+    end
   end
 end

--- a/lib/iopromise/cancel_context.rb
+++ b/lib/iopromise/cancel_context.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module IOPromise
+  class CancelContext
+    class << self
+      def context_stack
+        Thread.current[:iopromise_context_stack] ||= []
+      end
+
+      def current
+        context_stack.last
+      end
+
+      def push
+        new_ctx = CancelContext.new(current)
+        context_stack.push(new_ctx)
+        new_ctx
+      end
+
+      def pop
+        ctx = context_stack.pop
+        ctx.cancel
+        ctx
+      end
+
+      def with_new_context
+        ctx = push
+        yield ctx
+      ensure
+        pop
+      end
+    end
+
+    def initialize(parent)
+      parent.subscribe(self) unless parent.nil?
+    end
+
+    def subscribe(observer)
+      @observers ||= []
+      @observers.push observer
+    end
+
+    def cancel
+      return unless defined?(@observers)
+      @observers.each do |o|
+        o.cancel
+      end
+      @observers = []
+    end
+  end
+end

--- a/lib/iopromise/deferred/executor_pool.rb
+++ b/lib/iopromise/deferred/executor_pool.rb
@@ -3,6 +3,15 @@
 module IOPromise
   module Deferred
     class DeferredExecutorPool < ::IOPromise::ExecutorPool::Batch
+      def initialize(*)
+        super
+
+        # register a dummy reader that never fires, to indicate to the event loop that
+        # there is a valid, active ExecutorPool.
+        @pipe_rd, @pipe_wr = IO.pipe
+        @iop_monitor = ::IOPromise::ExecutorContext.current.register_observer_io(self, @pipe_rd, :r)
+      end
+
       def execute_continue
         if @current_batch.empty?
           next_batch

--- a/lib/iopromise/executor_context.rb
+++ b/lib/iopromise/executor_context.rb
@@ -29,6 +29,7 @@ module IOPromise
 
     def register(promise)
       @pending_registrations << promise
+      IOPromise::CancelContext.current&.subscribe(promise)
     end
 
     def wait_for_all_data(end_when_complete: nil)

--- a/lib/iopromise/executor_context.rb
+++ b/lib/iopromise/executor_context.rb
@@ -33,6 +33,10 @@ module IOPromise
     end
 
     def wait_for_all_data(end_when_complete: nil)
+      unless end_when_complete.nil?
+        raise IOPromise::CancelledError if end_when_complete.cancelled?
+      end
+
       loop do
         complete_pending_registrations
 
@@ -85,7 +89,7 @@ module IOPromise
       pending = @pending_registrations
       @pending_registrations = []
       pending.each do |promise|
-        register_now(promise)
+        register_now(promise) unless promise.cancelled?
       end
     end
 

--- a/lib/iopromise/executor_pool/base.rb
+++ b/lib/iopromise/executor_pool/base.rb
@@ -36,6 +36,9 @@ module IOPromise
       def promise_rejected(_reason, item)
         @pending.delete(item)
       end
+      def promise_cancelled(item)
+        @pending.delete(item)
+      end
 
       def begin_executing(item)
         item.beginning

--- a/lib/iopromise/rack/context_middleware.rb
+++ b/lib/iopromise/rack/context_middleware.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'iopromise'
+
+module IOPromise
+  module Rack
+    class ContextMiddleware
+      def initialize(app)
+        @app = app
+      end
+    
+      def call(env)
+        IOPromise::CancelContext.with_new_context do
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -79,6 +79,34 @@ RSpec.describe IOPromise::Base do
       expect(chained).to be_pending
     end
 
+    it "prevents successful promise chains after cancel" do
+      b = DummyPromise.new
+      b.cancel
+
+      expect(b).to be_cancelled
+
+      chained = b.then { |v| v }
+
+      b.fulfill('test')
+
+      expect(b).to be_pending
+      expect(chained).to be_pending
+    end
+
+    it "prevents failing promise chains after cancel" do
+      b = DummyPromise.new
+      b.cancel
+
+      expect(b).to be_cancelled
+
+      chained = b.rescue { |v| v }
+
+      b.reject('test')
+
+      expect(b).to be_pending
+      expect(chained).to be_pending
+    end
+
     it "does nothing on completed promises" do
       b = DummyPromise.new
       b.fulfill('foo')
@@ -92,6 +120,20 @@ RSpec.describe IOPromise::Base do
       expect(b).to_not be_pending
       expect(b).to be_fulfilled
       expect(b).to_not be_cancelled
+    end
+
+    it "allows Promise#then to work if already resolved" do
+      b = DummyPromise.new
+      b.fulfill('foo')
+
+      expect(b).to_not be_pending
+      expect(b).to be_fulfilled
+      expect(b).to_not be_cancelled
+
+      b.cancel
+
+      chained = b.then { |v| v }
+      expect(chained.value).to eq('foo')
     end
   end
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+RSpec.describe IOPromise::Base do
+  it "fulfills like a normal promise" do
+    b = IOPromise::Base.new
+    chained = b.then { |v| v }
+    expect(b).to be_pending
+    expect(chained).to be_pending
+
+    b.fulfill('test')
+
+    expect(b).to_not be_pending
+    expect(b).to be_fulfilled
+    expect(b.value).to eq('test')
+
+    expect(chained).to_not be_pending
+    expect(chained).to be_fulfilled
+    expect(chained.value).to eq('test')
+  end
+
+  it "rejects like a normal promise" do
+    b = IOPromise::Base.new
+    chained = b.then { |v| v }
+    expect(b).to be_pending
+    expect(chained).to be_pending
+
+    b.reject('test')
+
+    expect(b).to_not be_pending
+    expect(b).to be_rejected
+    expect(b.reason).to eq('test')
+
+    expect(chained).to_not be_pending
+    expect(chained).to be_rejected
+    expect(chained.reason).to eq('test')
+  end
+
+  context "#cancel" do
+    it "prevents handlers on fulfill" do
+      b = IOPromise::Base.new
+      chained = b.then { |v| v }
+      expect(b).to be_pending
+      expect(chained).to be_pending
+      expect(b).to_not be_cancelled
+
+      b.cancel
+
+      expect(b).to be_cancelled
+
+      b.fulfill('test')
+
+      expect(b).to_not be_pending
+      expect(b).to be_fulfilled
+      expect(b.value).to eq('test')
+
+      expect(chained).to be_pending
+    end
+
+    it "prevents handlers on reject" do
+      b = IOPromise::Base.new
+      chained = b.then { |v| v }
+      expect(b).to be_pending
+      expect(chained).to be_pending
+      expect(b).to_not be_cancelled
+
+      b.cancel
+
+      expect(b).to be_cancelled
+
+      b.reject('test')
+
+      expect(b).to_not be_pending
+      expect(b).to be_rejected
+      expect(b.reason).to eq('test')
+
+      expect(chained).to be_pending
+    end
+
+    it "does nothing on completed promises" do
+      b = IOPromise::Base.new
+      b.fulfill('foo')
+
+      expect(b).to_not be_pending
+      expect(b).to be_fulfilled
+      expect(b).to_not be_cancelled
+
+      b.cancel
+
+      expect(b).to_not be_pending
+      expect(b).to be_fulfilled
+      expect(b).to_not be_cancelled
+    end
+  end
+end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1,8 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe IOPromise::Base do
+  # Implement the very minimal requirements of an IOPromise::Base subclass
+  class DummyExecutorPool < IOPromise::ExecutorPool::Sequential
+  end
+  class DummyPromise < IOPromise::Base
+    def execute_pool
+      DummyExecutorPool.for(Thread.current)
+    end
+  end
+
   it "fulfills like a normal promise" do
-    b = IOPromise::Base.new
+    b = DummyPromise.new
     chained = b.then { |v| v }
     expect(b).to be_pending
     expect(chained).to be_pending
@@ -19,7 +28,7 @@ RSpec.describe IOPromise::Base do
   end
 
   it "rejects like a normal promise" do
-    b = IOPromise::Base.new
+    b = DummyPromise.new
     chained = b.then { |v| v }
     expect(b).to be_pending
     expect(chained).to be_pending
@@ -37,7 +46,7 @@ RSpec.describe IOPromise::Base do
 
   context "#cancel" do
     it "prevents handlers on fulfill" do
-      b = IOPromise::Base.new
+      b = DummyPromise.new
       chained = b.then { |v| v }
       expect(b).to be_pending
       expect(chained).to be_pending
@@ -49,15 +58,12 @@ RSpec.describe IOPromise::Base do
 
       b.fulfill('test')
 
-      expect(b).to_not be_pending
-      expect(b).to be_fulfilled
-      expect(b.value).to eq('test')
-
+      expect(b).to be_pending
       expect(chained).to be_pending
     end
 
     it "prevents handlers on reject" do
-      b = IOPromise::Base.new
+      b = DummyPromise.new
       chained = b.then { |v| v }
       expect(b).to be_pending
       expect(chained).to be_pending
@@ -69,15 +75,12 @@ RSpec.describe IOPromise::Base do
 
       b.reject('test')
 
-      expect(b).to_not be_pending
-      expect(b).to be_rejected
-      expect(b.reason).to eq('test')
-
+      expect(b).to be_pending
       expect(chained).to be_pending
     end
 
     it "does nothing on completed promises" do
-      b = IOPromise::Base.new
+      b = DummyPromise.new
       b.fulfill('foo')
 
       expect(b).to_not be_pending

--- a/spec/cancel_context_spec.rb
+++ b/spec/cancel_context_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'iopromise'
+
+RSpec.describe IOPromise::CancelContext do
+  it "cancels IOPromises that are pending after a CancelContext expires" do
+    deferred = nil
+    chained = nil
+
+    IOPromise::CancelContext.with_new_context do
+      deferred = IOPromise::Deferred.new { 123 }
+      chained = deferred.then { 456 }
+
+      expect(deferred).to be_pending
+      expect(deferred).to_not be_cancelled
+      expect(chained).to be_pending
+      expect(chained).to_not be_cancelled
+    end
+
+    expect(deferred).to be_pending
+    expect(deferred).to be_cancelled
+    expect(chained).to be_pending
+    expect(chained).to_not be_cancelled
+  end
+
+  it "cancels IOPromises that are pending after a nested CancelContext expires" do
+    deferred = nil
+    deferred2 = nil
+
+    IOPromise::CancelContext.with_new_context do
+      deferred = IOPromise::Deferred.new { 123 }
+
+      expect(deferred).to be_pending
+      expect(deferred).to_not be_cancelled
+
+      IOPromise::CancelContext.with_new_context do
+        deferred2 = IOPromise::Deferred.new { 123 }
+  
+        expect(deferred2).to be_pending
+        expect(deferred2).to_not be_cancelled
+      end
+
+      expect(deferred2).to be_pending
+      expect(deferred2).to be_cancelled
+    end
+
+    expect(deferred).to be_pending
+    expect(deferred).to be_cancelled
+  end
+
+  it "cancels IOPromises when a CancelContext block fails" do
+    deferred = nil
+
+    expect {
+      IOPromise::CancelContext.with_new_context do
+        deferred = IOPromise::Deferred.new { 123 }
+  
+        expect(deferred).to be_pending
+        expect(deferred).to_not be_cancelled
+  
+        raise 'fail'
+      end
+    }.to raise_error /fail/
+
+    expect(deferred).to be_pending
+    expect(deferred).to be_cancelled
+  end
+end

--- a/spec/rack/context_middleware_spec.rb
+++ b/spec/rack/context_middleware_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'iopromise'
+require 'iopromise/rack/context_middleware'
+
+RSpec.describe IOPromise::Rack::ContextMiddleware do
+  subject { described_class.new(app) }
+  let(:request) { Rack::MockRequest.new(subject) }
+
+  context "without any promises" do
+    let(:app) { lambda {|env| [200, {'Content-Type' => 'text/plain'}, ['OK']]} }
+    
+    it "allows requests to complete" do
+      response = request.get("/some/path")
+      expect(response.status).to eq(200)
+    end
+  end
+
+  context "with completing and pending IOPromises" do
+    let(:req_storage) { {} }
+    let(:app) { lambda { |env|
+      req_storage[:deferred] = IOPromise::Deferred.new { 123 }
+      req_storage[:deferred].sync
+      req_storage[:incomplete] = IOPromise::Deferred.new { 123 }
+      [200, {'Content-Type' => 'text/plain'}, ['OK']]
+    } }
+    
+    it "allows requests to complete" do
+      response = request.get("/some/path")
+      expect(response.status).to eq(200)
+    end
+
+    it "doesn't touch completed IOPromises" do
+      response = request.get("/some/path")
+      expect(req_storage[:deferred]).to be_fulfilled
+      expect(req_storage[:deferred]).to_not be_cancelled
+    end
+
+    it "cancels incomplete IOPromises" do
+      response = request.get("/some/path")
+      expect(req_storage[:incomplete]).to be_pending
+      expect(req_storage[:incomplete]).to be_cancelled
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a few concepts that allow IOPromises to be cancelled, or made inert, when a context/block scope is left. This is very similar to some of the concepts in golang's [`Context`](https://blog.golang.org/context). The diagrams in [this great post](https://www.sohamkamani.com/golang/context-cancellation-and-values/) explain the problem that Go was solving and that is the same problem that this PR aims to solve for IOPromise.

This PR is best viewed as the individual commits, which incrementally add this functionality.

Essentially this solves a potential concurrency risk introduced by IOPromises, which is that certain work can be batched up inside `then` handlers of IOPromise objects, which could reference shared scope, but may live beyond a request lifecycle by either missing a `sync` call or raising before one. In successful requests, this wouldn't present an issue since we would expect that all these promises would be `sync`ed at some point, ensuring that everything is cleaned up. However, if a request _fails_ due to an exception, it's possible that the `.sync` call would be bypassed and the promises could continue to live inside the IOPromise execution contexts. Since we expect the underlying storage connections to continue across requests, we can't simply throw these promises away.

This PR prevents these handlers from inadvertently executing late, by enabling every `IOPromise::Base` promise to be made inert by `cancel`ing it. It then creates a `CancelContext` around a block, which ensures that any promises that are still waiting on IO are at the very least prevented from executing promise chains, as would be the case for normal Promise instances that are not part of IOPromise. They would then be cleaned up by GC once IOPromise is done with them. There is also a Rack middleware that uses this functionality. 

The best place to see the problem and the way the context middleware fixes it is in this test: https://github.com/iopromise-ruby/iopromise/blob/c3d708db076ac90ada01e436d66d9e716c35c761/spec/rack/context_middleware_spec.rb

The best place to see that non-IOPromise chains are disabled as expected is in this test: https://github.com/iopromise-ruby/iopromise/commit/1f6e76c3064d739cd2d7151aeacd14c4400fc18e#diff-ef76ba7327c65542594766085cf6e813bec74b11fbf6517573d1948bfa34d48aR6

You can imagine a trivial but common example where this would happen, say inside a Rails view, an IOPromise to perform some slow query is begun, then an unrelated exception occurs before the call to `.sync`. Say this promise had a `then` handler with some more IO queries. This would leave the IOPromise executing, and eventually the `.then` handler would execute and potentially initiate another IO operation even though the request has already long finished. Instead, with this PR, in every case the IOPromise will be prevented from continuing.

Additionally, specific IOPromise implementations can optionally extend the `cancel` method in their subclass to actually cancel any downstream work that's pending - this is left up to individual implementations to decide in their own repos.

/cc @tma @mclark