### PR TITLE
Add support for time delays for Deferred promises.

### DIFF
--- a/lib/iopromise/deferred.rb
+++ b/lib/iopromise/deferred.rb
@@ -5,8 +5,8 @@ require_relative 'deferred/promise'
 module IOPromise
   module Deferred
     class << self
-      def new(&block)
-        ::IOPromise::Deferred::DeferredPromise.new(&block)
+      def new(*args, **kwargs, &block)
+        ::IOPromise::Deferred::DeferredPromise.new(*args, **kwargs, &block)
       end
     end
   end

--- a/lib/iopromise/deferred/promise.rb
+++ b/lib/iopromise/deferred/promise.rb
@@ -5,10 +5,14 @@ require_relative 'executor_pool'
 module IOPromise
   module Deferred
     class DeferredPromise < ::IOPromise::Base
-      def initialize(&block)
+      def initialize(timeout = nil, &block)
         super()
     
         @block = block
+        
+        unless timeout.nil?
+          @defer_until = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+        end
     
         ::IOPromise::ExecutorContext.current.register(self) unless @block.nil?
       end
@@ -32,6 +36,15 @@ module IOPromise
         rescue => exception
           reject(exception)
         end
+      end
+
+      def time_until_execution
+        return 0 unless defined?(@defer_until)
+
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        return 0 if now > @defer_until
+
+        @defer_until - now
       end
     end
   end

--- a/lib/iopromise/deferred/promise.rb
+++ b/lib/iopromise/deferred/promise.rb
@@ -5,7 +5,7 @@ require_relative 'executor_pool'
 module IOPromise
   module Deferred
     class DeferredPromise < ::IOPromise::Base
-      def initialize(timeout = nil, &block)
+      def initialize(timeout: nil, &block)
         super()
     
         @block = block

--- a/spec/deferred_spec.rb
+++ b/spec/deferred_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe IOPromise::Deferred do
 
   context "with delay" do
     it "delays execution of a delayed promise" do
-      long_deferred = IOPromise::Deferred.new(0.5) { 123 }
+      long_deferred = IOPromise::Deferred.new(timeout: 0.5) { 123 }
       expect(long_deferred).to be_pending
 
       deferred = IOPromise::Deferred.new { 123 }
@@ -78,10 +78,10 @@ RSpec.describe IOPromise::Deferred do
     it "delays execution of concurrent delayed promises with different times" do
       promises = []
       promises << IOPromise::Deferred.new { Time.now }
-      promises << IOPromise::Deferred.new(0.5) { Time.now }
-      promises << IOPromise::Deferred.new(1) { Time.now }
-      promises << IOPromise::Deferred.new(1.5) { Time.now }
-      promises << IOPromise::Deferred.new(2) { Time.now }
+      promises << IOPromise::Deferred.new(timeout: 0.5) { Time.now }
+      promises << IOPromise::Deferred.new(timeout: 1) { Time.now }
+      promises << IOPromise::Deferred.new(timeout: 1.5) { Time.now }
+      promises << IOPromise::Deferred.new(timeout: 2) { Time.now }
 
       Promise.all(promises).sync
 
@@ -99,7 +99,7 @@ RSpec.describe IOPromise::Deferred do
     it "fully empties the pending promise list in the execution pool" do
       Promise.all([
         IOPromise::Deferred.new { Time.now },
-        IOPromise::Deferred.new(0.5) { Time.now },
+        IOPromise::Deferred.new(timeout: 0.5) { Time.now },
       ]).sync
 
       pending = IOPromise::Deferred::DeferredExecutorPool.for(Thread.current).instance_variable_get(:@pending)
@@ -126,7 +126,7 @@ RSpec.describe IOPromise::Deferred do
         return promise if times == 0
   
         promise.rescue do |ex|
-          IOPromise::Deferred.new(0.5) do
+          IOPromise::Deferred.new(timeout: 0.5) do
             retry_promise_block(times - 1, &block)
           end
         end

--- a/spec/deferred_spec.rb
+++ b/spec/deferred_spec.rb
@@ -59,4 +59,105 @@ RSpec.describe IOPromise::Deferred do
     expect(begin_called).to eq(1)
     expect(finish_called).to eq(1)
   end
+
+  context "with delay" do
+    it "delays execution of a delayed promise" do
+      long_deferred = IOPromise::Deferred.new(0.5) { 123 }
+      expect(long_deferred).to be_pending
+
+      deferred = IOPromise::Deferred.new { 123 }
+      expect(long_deferred).to be_pending
+      expect(deferred).to be_pending
+
+      deferred.sync
+
+      expect(long_deferred).to be_pending
+      expect(deferred).to be_fulfilled
+    end
+
+    it "delays execution of concurrent delayed promises with different times" do
+      promises = []
+      promises << IOPromise::Deferred.new { Time.now }
+      promises << IOPromise::Deferred.new(0.5) { Time.now }
+      promises << IOPromise::Deferred.new(1) { Time.now }
+      promises << IOPromise::Deferred.new(1.5) { Time.now }
+      promises << IOPromise::Deferred.new(2) { Time.now }
+
+      Promise.all(promises).sync
+
+      exec_times = promises.map do |p|
+        expect(p).to be_fulfilled
+        p.value.to_f
+      end
+
+      expect(exec_times[1] - exec_times[0]).to be > 0.4
+      expect(exec_times[2] - exec_times[1]).to be > 0.4
+      expect(exec_times[3] - exec_times[2]).to be > 0.4
+      expect(exec_times[4] - exec_times[3]).to be > 0.4
+    end
+
+    it "fully empties the pending promise list in the execution pool" do
+      Promise.all([
+        IOPromise::Deferred.new { Time.now },
+        IOPromise::Deferred.new(0.5) { Time.now },
+      ]).sync
+
+      pending = IOPromise::Deferred::DeferredExecutorPool.for(Thread.current).instance_variable_get(:@pending)
+      expect(pending).to be_empty
+    end
+
+    context "with deferred-based retries" do
+      class FlakeyRPC
+        def initialize
+          @attempts = 0
+        end
+  
+        def execute
+          Promise.resolve.then do
+            @attempts = @attempts + 1
+            raise "need to retry this, attempts=#{@attempts}!" if @attempts < 4
+            "all good on attempt=#{@attempts}"
+          end
+        end
+      end
+  
+      def retry_promise_block(times, &block)
+        promise = block.call
+        return promise if times == 0
+  
+        promise.rescue do |ex|
+          IOPromise::Deferred.new(0.5) do
+            retry_promise_block(times - 1, &block)
+          end
+        end
+      end
+  
+      it "retries with delays and rejects when it always fails" do
+        flakey = FlakeyRPC.new
+        failing_flake = retry_promise_block(2) do
+          flakey.execute
+        end
+
+        start = Time.now
+        expect { failing_flake.sync }.to raise_exception /need to retry this, attempts=3/
+        duration = Time.now - start
+        expect(duration).to be > 1 # 2 retries
+        expect(duration).to be < 1.5 # but no more
+      end
+  
+      it "retries with delays and fulfills when the last succeeds" do
+        flakey = FlakeyRPC.new
+        success_flake = retry_promise_block(5) do
+          flakey.execute
+        end
+
+        start = Time.now
+        result = success_flake.sync
+        expect(result).to eq('all good on attempt=4')
+        duration = Time.now - start
+        expect(duration).to be > 1.5 # 3 retries
+        expect(duration).to be < 2 # but not more, should stop at first success
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds support for `Deferred` promises to delay execution until some time has elapsed. Once that time has elapsed, the block is executed just like it is currently. It uses the existing "sleep until IO is ready, or timeout after X" functionality of IOPromise's main loop, by waiting on a never-ready IO object.

This is extremely useful in the case where retries or backoff are implemented, and avoids application code running blocking `sleep` calls. Instead, the delay happens within the IOPromise select loop, meaning that other IO operations can progress during this timeout.

The tests here demonstrate and test a basic version of a promise-based retry loop with a 0.5 second delay between attempts:
```ruby
      def retry_promise_block(times, &block)
        promise = block.call
        return promise if times == 0

        promise.rescue do |ex|
          IOPromise::Deferred.new(0.5) do
            retry_promise_block(times - 1, &block)
          end
        end
      end
```

It's left up to application code to implement this sort of retry/back-off loop, but the addition of the timeout parameter to the `Deferred` allows this functionality with a pretty simple pattern.

/cc @tma @mclark 