### PR TITLE
DataLoader: Add support for lambda/proc based promise pattern

### DIFF
--- a/lib/iopromise/data_loader.rb
+++ b/lib/iopromise/data_loader.rb
@@ -15,9 +15,9 @@ module IOPromise
 
         args.each do |arg|
           if build_func.nil?
-            self.class_eval("def #{arg}_promise;@#{arg};end")
+            self.class_eval("def async_#{arg};@#{arg};end")
           else
-            self.define_method("#{arg}_promise") do
+            self.define_method("async_#{arg}") do
               @promised_data_memo ||= {}
               @promised_data_memo[arg] ||= if build_func.arity == 1
                 self.instance_exec(arg, &build_func)
@@ -27,7 +27,7 @@ module IOPromise
             end
           end
 
-          self.class_eval("def #{arg};#{arg}_promise.sync;end")
+          self.class_eval("def #{arg};async_#{arg}.sync;end")
         end
       end
   
@@ -42,7 +42,7 @@ module IOPromise
 
     def data_promises
       self.class.promised_data_keys.flat_map do |k|
-        p = send("#{k}_promise")
+        p = send("async_#{k}")
         case p
         when ::IOPromise::DataLoader
           # greedily, recursively preload all nested data that we know about immediately

--- a/spec/data_loader_spec.rb
+++ b/spec/data_loader_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe IOPromise::DataLoader do
     example = ExampleDataLoader.new({ :foo => 123, :bar => 456 }, :example)
     expect(example.dynamic_no_args).to eq("dynamic without args (ident=example, calls=1)")
     expect(example.dynamic_no_args).to eq("dynamic without args (ident=example, calls=1)")
-    expect(example.dynamic_no_args_promise.sync).to eq("dynamic without args (ident=example, calls=1)")
+    expect(example.async_dynamic_no_args.sync).to eq("dynamic without args (ident=example, calls=1)")
   end
 
   it "doesn't memoise lambda promises across instances" do

--- a/spec/data_loader_spec.rb
+++ b/spec/data_loader_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe IOPromise::DataLoader do
   class ExampleDataLoader
     include IOPromise::DataLoader
 
-    attr_promised_data :foo
-    attr_promised_data :bar
-    attr_promised_data :dynamic1, :dynamic2, -> (id) do
-      IOPromise::Deferred.new { "dynamic from #{id} (ident=#{@ident})" }
+    attr_async_data :foo
+    attr_async_data :bar
+    attr_async_data :dynamic1, -> do
+      IOPromise::Deferred.new { "dynamic from 1 (ident=#{@ident})" }
     end
-    attr_promised_data :dynamic_no_args, -> do
+    attr_async_data :dynamic2, -> do
       @calls ||= 0
       @calls += 1
-      IOPromise::Deferred.new { "dynamic without args (ident=#{@ident}, calls=#{@calls})" }
+      IOPromise::Deferred.new { "dynamic from 2 (ident=#{@ident}, calls=#{@calls})" }
     end
 
     def initialize(data_source, ident)
@@ -29,7 +29,7 @@ RSpec.describe IOPromise::DataLoader do
   class AnotherDataLoader
     include IOPromise::DataLoader
 
-    attr_promised_data :baz
+    attr_async_data :baz
 
     def initialize(data_source)
       @baz = IOPromise::Deferred.new { data_source[:baz] }
@@ -39,7 +39,7 @@ RSpec.describe IOPromise::DataLoader do
   class BrokenDataLoader
     include IOPromise::DataLoader
 
-    attr_promised_data :broken
+    attr_async_data :broken
 
     def initialize
       @broken = ::Promise.new
@@ -49,7 +49,9 @@ RSpec.describe IOPromise::DataLoader do
 
   class ParentDataLoader
     include IOPromise::DataLoader
-    attr_promised_data :parent_thing, :example_component, :another_component
+    attr_async_data :parent_thing
+    attr_async_data :example_component
+    attr_async_data :another_component
 
     def initialize(data_source)
       @parent_thing = IOPromise::Deferred.new { data_source[:parent_thing] }
@@ -59,7 +61,7 @@ RSpec.describe IOPromise::DataLoader do
   end
 
   it "registers the promised data keys for the class" do
-    expect(ExampleDataLoader.promised_data_keys).to eq([:foo, :bar, :dynamic1, :dynamic2, :dynamic_no_args])
+    expect(ExampleDataLoader.promised_data_keys).to eq([:foo, :bar, :dynamic1, :dynamic2])
     expect(AnotherDataLoader.promised_data_keys).to eq([:baz])
     expect(BrokenDataLoader.promised_data_keys).to eq([:broken])
   end
@@ -72,16 +74,15 @@ RSpec.describe IOPromise::DataLoader do
 
   it "creates attr readers that use the lambda to generate the promise when provided" do
     example = ExampleDataLoader.new({ :foo => 123, :bar => 456 }, :example)
-    expect(example.dynamic1).to eq("dynamic from dynamic1 (ident=example)")
-    expect(example.dynamic2).to eq("dynamic from dynamic2 (ident=example)")
-    expect(example.dynamic_no_args).to eq("dynamic without args (ident=example, calls=1)")
+    expect(example.dynamic1).to eq("dynamic from 1 (ident=example)")
+    expect(example.dynamic2).to eq("dynamic from 2 (ident=example, calls=1)")
   end
 
   it "memoises results of lambda promises" do
     example = ExampleDataLoader.new({ :foo => 123, :bar => 456 }, :example)
-    expect(example.dynamic_no_args).to eq("dynamic without args (ident=example, calls=1)")
-    expect(example.dynamic_no_args).to eq("dynamic without args (ident=example, calls=1)")
-    expect(example.async_dynamic_no_args.sync).to eq("dynamic without args (ident=example, calls=1)")
+    expect(example.dynamic2).to eq("dynamic from 2 (ident=example, calls=1)")
+    expect(example.dynamic2).to eq("dynamic from 2 (ident=example, calls=1)")
+    expect(example.async_dynamic2.sync).to eq("dynamic from 2 (ident=example, calls=1)")
   end
 
   it "doesn't memoise lambda promises across instances" do
@@ -89,12 +90,10 @@ RSpec.describe IOPromise::DataLoader do
     another = ExampleDataLoader.new({ :foo => 123, :bar => 456 }, :another)
     example.sync
     another.sync
-    expect(example.dynamic1).to eq("dynamic from dynamic1 (ident=example)")
-    expect(example.dynamic2).to eq("dynamic from dynamic2 (ident=example)")
-    expect(example.dynamic_no_args).to eq("dynamic without args (ident=example, calls=1)")
-    expect(another.dynamic1).to eq("dynamic from dynamic1 (ident=another)")
-    expect(another.dynamic2).to eq("dynamic from dynamic2 (ident=another)")
-    expect(another.dynamic_no_args).to eq("dynamic without args (ident=another, calls=1)")
+    expect(example.dynamic1).to eq("dynamic from 1 (ident=example)")
+    expect(example.dynamic2).to eq("dynamic from 2 (ident=example, calls=1)")
+    expect(another.dynamic1).to eq("dynamic from 1 (ident=another)")
+    expect(another.dynamic2).to eq("dynamic from 2 (ident=another, calls=1)")
   end
 
   it "creates attr readers that sync and handle failure by raising the reason" do

--- a/spec/view_component_spec.rb
+++ b/spec/view_component_spec.rb
@@ -9,8 +9,8 @@ require 'action_controller'
 RSpec.describe IOPromise::ViewComponent do
   class ExampleComponent < ViewComponent::Base
     include IOPromise::ViewComponent::DataLoader
-    attr_promised_data :foo
-    attr_promised_data :bar
+    attr_async_data :foo
+    attr_async_data :bar
 
     def initialize(data_source)
       @foo = IOPromise::Deferred.new { data_source[:foo] }
@@ -24,7 +24,7 @@ RSpec.describe IOPromise::ViewComponent do
 
   class AnotherComponent < ViewComponent::Base
     include IOPromise::ViewComponent::DataLoader
-    attr_promised_data :baz
+    attr_async_data :baz
 
     def initialize(data_source)
       @baz = IOPromise::Deferred.new { data_source[:baz] }
@@ -33,7 +33,7 @@ RSpec.describe IOPromise::ViewComponent do
 
   class BrokenComponent < ViewComponent::Base
     include IOPromise::ViewComponent::DataLoader
-    attr_promised_data :broken
+    attr_async_data :broken
 
     def initialize
       @broken = ::Promise.new
@@ -43,7 +43,9 @@ RSpec.describe IOPromise::ViewComponent do
 
   class ParentComponent < ViewComponent::Base
     include IOPromise::ViewComponent::DataLoader
-    attr_promised_data :parent_thing, :example_component, :another_component
+    attr_async_data :parent_thing
+    attr_async_data :example_component
+    attr_async_data :another_component
 
     def initialize(data_source)
       @parent_thing = IOPromise::Deferred.new { data_source[:parent_thing] }


### PR DESCRIPTION
This PR proposes a way of potentially simplifying the sort of pattern around memoising a promise as part of an instance, inspired by the [lambda slots in ViewComponents](https://viewcomponent.org/guide/slots.html#lambda-slots) (which I thought were a really clean/simple pattern). I'd love some 🤔 on this pattern and any potential similar things we could do to make this `DataLoader` pattern really easy and clean to adopt.

Rather than always relying on `attr_promised_data` acting like an `attr_reader` implementation and needing an instance variable to have been set prior to calling the reader, this allows one or more promised data attributes to be set up that are generated as needed using a provided lamba/proc. This promise is memoized automatically to avoid the need to explicitly do this, since this is the behaviour one would expect from a piece of data that should be promised once and then remain available as a promise for any number of accesses.

A more complete example that actually performs IO might look like this:
```ruby
require 'iopromise'
require 'iopromise/data_loader'
require 'iopromise/faraday'
require 'json'

class RemoteDataLoader
  include IOPromise::DataLoader

  attr_promised_data :latest_iopromise_release, -> do
    @conn.get('/repos/iopromise-ruby/iopromise/releases/latest').then do |response|
      JSON.load(response.body)['tag_name']
    end
  end

  attr_promised_data :github_meta_ips, -> do
    @conn.get('/meta').then do |response|
      JSON.load(response.body)['web']
    end
  end

  def initialize
    @conn = IOPromise::Faraday.new('https://api.github.com/')
  end
end

dl = RemoteDataLoader.new
dl.sync # loads both endpoints concurrently
puts "Latest release is #{dl.latest_iopromise_release}"
puts "GitHub's public IPs are: #{dl.github_meta_ips}"
```

As per the current implementation of `DataLoader`, any of these promised data keys will be built and synced on together, ensuring that any nested IOPromises run concurrently. The provided lambda/proc can optionally take a single argument, the name of the attribute, allowing for multiple similar attributes to be created at once. The lambda/proc is executed in instance scope, so can access instance variables.

/cc @iopromise-ruby/iopromise-reviewers 