### PR TITLE
Release version 0.1.5 (data loader improvements)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    iopromise (0.1.4)
+    iopromise (0.1.5)
       nio4r
       promise.rb (~> 0.7.4)
 

--- a/lib/iopromise/version.rb
+++ b/lib/iopromise/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IOPromise
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end


### PR DESCRIPTION
Releases the following to allow use of the data loader lambda pattern (I'll wait for the last change here to merge before :ship: this because it will start making it harder to change names going forward):
 * https://github.com/iopromise-ruby/iopromise/pull/5
 * https://github.com/iopromise-ruby/iopromise/pull/7
 * https://github.com/iopromise-ruby/iopromise/pull/8